### PR TITLE
don't try to inject nonce attributes into RedirectResponse content

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -12,6 +12,7 @@ use OFFLINE\CSP\Console\DisableCSPPlugin;
 use OFFLINE\CSP\Models\CSPSettings;
 use OFFLINE\LaravelCSP\Nonce\NonceGenerator;
 use OFFLINE\LaravelCSP\Nonce\RandomString;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use System\Classes\PluginBase;
 use System\Controllers\Settings;
 use System\Traits\ViewMaker;
@@ -38,6 +39,10 @@ class Plugin extends PluginBase
         if (CSPSettings::get('inject_nonce')) {
             // Automatically inject the nonce attribute into each script and style tag.
             Event::listen('cms.page.postprocess', function ($controller, $url, $page, $dataHolder) {
+                if ($dataHolder->content instanceof RedirectResponse) {
+                    return;
+                }
+
                 $dataHolder->content = NonceInjector::withNonce(app('csp-nonce'))->inject($dataHolder->content);
             });
         }


### PR DESCRIPTION
Great plugin, thank you very much for that!

When trying it out, I noticed that the redirect from Rainlabs translate plugin, in connection with the forceURLScheme setting, was visible on the page for a short time. I guess this is because the redirect is built during runtime and comes as a response to a page render.

Since RedirectResponses don't have anything to decorate anyway, it should be safe to just skip the nonce injection for this kind of content/response.

I am not 100% sure if it is a perfect solution, but it solves this problem.
There might be other kinds of content in the "dataHolder", but since the "normal" content is a string , I'm not sure if a reversed check (whitelisting content that should have nonce injected instead of blacklisting content like the RedirectResponse) is possible.
