### PR TITLE
Update routes.php

### DIFF
--- a/routes.php
+++ b/routes.php
@@ -7,7 +7,7 @@ use OFFLINE\CSP\Models\CSPLog;
 
     $data = object_get(json_decode($input, false), 'csp-report');
     if (!$data) {
-        return response('Invalid request', 500);
+        return response('Invalid request', 400);
     }
 
     $log = [];


### PR DESCRIPTION
Sending a server error back means that the server has an issue but the server doesn't care about the empty (or invalid) request so a 400 error is better on the place.

