### PR TITLE
Adds missing default for worker_src

### DIFF
--- a/models/CSPSettings.php
+++ b/models/CSPSettings.php
@@ -23,6 +23,7 @@ class CSPSettings extends Model
         $this->require_trusted_types = ["'script'"];
         $this->script_src = ['nonce', 'unsafe-inline'];
         $this->style_src = ['self', 'nonce', 'unsafe-inline'];
+        $this->worker_src = ['none'];
         $this->object_src = ['none'];
         $this->base_uri = ['none'];
         $this->inject_nonce = true;


### PR DESCRIPTION
Hello!

This value is required by `CSPMiddleware::patchPolicyForBackend` and throws an error when saving the settings form on a fresh install (tested October CMS v2.1.22). Unsure if this is a reasonable default but happy to adjust.

Thanks!